### PR TITLE
[Feat] Add release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Create Archive Release
+        uses: thedoctor0/zip-release@master
+        with:
+          filename: 'release.zip'
+          exclusions: '*.git*'
+      - name: Upload Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: 'release.zip'
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### This action will only trigger when we push tags to the repository.
- Once triggered, it will first checkout the master(or main) branch using the “native” action for checkout. Afterwards it will zip using thedoctor0’s Zip Release to zip up the contents of the repository and use the Release Action to create a new release using the newly created zip file as artifact.